### PR TITLE
[Protoss Carrier]: Fixed skill1 (wards)

### DIFF
--- a/cfg/source-python/wcs/Racepack Novakiller - (Version 1.0.4B).ini
+++ b/cfg/source-python/wcs/Racepack Novakiller - (Version 1.0.4B).ini
@@ -162,7 +162,7 @@
 	skillneeded	   = "0|0|0|8"
 	category	   = "All races"
 	[[skill1]]
-		setting	= "es_xset wcs_count 1;es_xset wcs_params 13_10_125|es_xset wcs_count 1;es_xset wcs_params 14_11_150|es_xset wcs_count 2;es_xset wcs_params 16_12_175|es_xset wcs_count 2;es_xset wcs_params 18_13_200|es_xset wcs_count 3;es_xset wcs_params 20_15_225"
+		setting	= "es_xset wcs_count 1;es_xset wcs_duration 13;es_xset wcs_dmg 10;es_xset wcs_range 125|es_xset wcs_count 1;es_xset wcs_duration 14;es_xset wcs_dmg 11;es_xset wcs_range 150|es_xset wcs_count 2;es_xset wcs_duration 16;es_xset wcs_dmg 12;es_xset wcs_range 175|es_xset wcs_count 2;es_xset wcs_duration 18;es_xset wcs_dmg 13;es_xset wcs_range 200|es_xset wcs_count 3;es_xset wcs_duration 20;es_xset wcs_dmg 15;es_xset wcs_range 225"
 		cmd		= "es_xdoblock wcs/tools/manifest/protoss_carrier/ward"
 		sfx		= ""
 	[[skill2]]


### PR DESCRIPTION
[Interceptors]
wcs_params seems deprecated, couldn't find any core code behind it. Setting them individually fixed the issue.
Recoding wcs_params might be a good idea to keep backwards compatibility with old race code.